### PR TITLE
Travis: Use latest released versions of JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ before_install: "gem install rjack-tarpit -v'~>2.1' || \
       ( sleep 5; gem install rjack-tarpit -v'~>2.1' )"
 bundler_args: ""
 rvm:
-  - jruby-1.7.24
-  - jruby-9.0.5.0
+  - jruby-1.7.27
+  - jruby-9.1.13.0
   - jruby-head
 script: "bundle exec rake test"
 matrix:


### PR DESCRIPTION
This PR is about updating the CI matrix to latest generally available in each release series.

A note: JRuby's S3 bucket had permissions issues, and only _some_ of the distributed versions in it were recovered, these latest versions were recovered immediately
